### PR TITLE
Feature/fce 27 run code coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
   - $HOME/.m2
   - $HOME/google-cloud-sdk/
 
-script: "mvn cobertura:cobertura"
+script: "mvn cobertura:cobertura -Ptest"
 
 before_install:
   - gcloud version || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ deploy:
   provider: script
   #attempting to run test with in-memory profile then package without
   script: (mvn -Ptest clean package -DskipTests && exec mvn gcloud:deploy -DskipTests)
-  on: master
+  on: feature/FCE-27-run-code-coverage-report
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 install:
   - gcloud config set project blissful-cell-141318
 
-script: "mvn -Ptest verify"
+# script: "mvn -Ptest verify"
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ deploy:
   provider: script
   #attempting to run test with in-memory profile then package without
   script: (mvn -Ptest clean package -DskipTests && exec mvn gcloud:deploy -DskipTests)
-  on: feature/FCE-27-run-code-coverage-report
+  on:
+    all_branches: true
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ cache:
   - $HOME/.m2
   - $HOME/google-cloud-sdk/
 
-# script: "mvn cobertura:cobertura"
+script: "mvn cobertura:cobertura"
+
 before_install:
   - gcloud version || true
   - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
                 <configuration>
                     <gcloud_directory>${gcloud.directory}</gcloud_directory>
                     <gcloud_project>blissful-cell-141318</gcloud_project>
-                    <verbosity>debug</verbosity>
+                    <verbosity>info</verbosity>
                     <set_default>true</set_default>
                     <log_level>info</log_level>
                 </configuration>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -55,3 +55,6 @@ spring.datasource.schema=classpath:/sql/schema.sql
 authentication.oauth.clientid=flashdev
 authentication.oauth.secret=secret
 authentication.oauth.tokenValidityInSeconds=7200
+
+# Logging level
+logging.level.org.springframework: INFO

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,4 +57,5 @@ authentication.oauth.secret=secret
 authentication.oauth.tokenValidityInSeconds=7200
 
 # Logging level
-logging.level.org.springframework: INFO
+logging.level.org.springframework: ERROR
+spring.jpa.properties.hibernate.show_sql: true


### PR DESCRIPTION
@ayacub @irieb   Please review

1) Travis now runs mvn cobertura, reports gets uploaded to code.cov
2) Reduced log4j verbosity to ERROR for org.springframework.  see application.properties.  The reason is that Travis terminate builds if logging > 4MB.
